### PR TITLE
fix TypeError: 'float' object cannot be interpreted as an integer

### DIFF
--- a/randomtimestamp/core.py
+++ b/randomtimestamp/core.py
@@ -210,7 +210,7 @@ def get_datetime(start_datetime: datetime, end_datetime: datetime) -> datetime:
     Core function to generate a random timestamp between two datetime objects.
     Should not be imported.
     """
-    gap_seconds = (end_datetime - start_datetime).total_seconds()
+    gap_seconds = int((end_datetime - start_datetime).total_seconds())
     random_gap_seconds = randint(0, gap_seconds)
     random_datetime = start_datetime + timedelta(seconds=random_gap_seconds)
     return random_datetime


### PR DESCRIPTION
Bug fix:

newer/recent python versions (eg. python-3.13) changed how
`().total_seconds()` works,such that it now returns a float() instead of the expected int().  This results in all commands failing with: `TypeError: 'float' object cannot be interpreted as an integer`

Forcing to int() before passing to randint() works around this bug. 

Closes #2 